### PR TITLE
decorator_spec.rbでRSpec/DescribedClassのエラーが出るため、例外に追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,10 @@ inherit_gem:
     # uncomment if use rspec cops
     - "config/rspec.yml"
 
+RSpec/DescribedClass:
+  Exclude:
+    - 'spec/decorators/**_spec.rb'
+
 AllCops:
   TargetRubyVersion: 2.5
   # uncomment if use rails cops


### PR DESCRIPTION
decorator_spec.rbでRSpec/DescribedClassのエラーが出るため、例外に追加