### PR TITLE
bulma-extensionsのバージョンアップの影響により、bulma-dividerを個別に指定するように修正

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,5 +1,5 @@
 @import '~bulma/bulma';
-@import '~bulma-extensions/dist/bulma-extensions.min';
+@import '~bulma-extensions/bulma-divider/dist/css/bulma-divider.min';
 
 $mdi-font-path: '~mdi/fonts/';
 @import '~mdi/scss/materialdesignicons';


### PR DESCRIPTION
bulma-extensionsのバージョンアップの影響で既存の指定方法では、bulma-extensionsのすべてを読み込まなくなったため、使用するものを個別に指定するように修正しました。