### PR TITLE
Enhance Avo resources and Makefile for music management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,9 @@ bundle:
 
 bash-admin:
 	docker compose run --rm admin bash
+
+rubocop:
+	docker compose run --rm admin bundle exec rubocop
+
+rubocop-autocorrect:
+	docker compose run --rm admin bundle exec rubocop -a

--- a/admin/Gemfile
+++ b/admin/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby file: '.ruby-version'
+ruby file: ".ruby-version"
 
 gem "rails", "~> 8.0.1"
 gem "propshaft"

--- a/admin/app/avo/resources/album.rb
+++ b/admin/app/avo/resources/album.rb
@@ -1,21 +1,21 @@
 class Avo::Resources::Album < Avo::BaseResource
   self.title = :title
   self.translation_key = "activerecord.resources.album"
-  self.includes = [:release_circle, :event_day, :album_discs, :circles]
+  self.includes = [ :release_circle, :event_day, :album_discs, :circles ]
 
   def fields
     field :id, as: :id, translation_key: "activerecord.attributes.album.id"
-    field :created_at, as: :date_time, translation_key: "activerecord.attributes.album.created_at", hide_on: [:index]
-    field :updated_at, as: :date_time, translation_key: "activerecord.attributes.album.updated_at", hide_on: [:index]
+    field :created_at, as: :date_time, translation_key: "activerecord.attributes.album.created_at", hide_on: [ :index ]
+    field :updated_at, as: :date_time, translation_key: "activerecord.attributes.album.updated_at", hide_on: [ :index ]
 
     field :name, as: :text, required: true,
       translation_key: "activerecord.attributes.album.name",
       help: "アルバム名"
-    
+
     field :name_reading, as: :text,
       translation_key: "activerecord.attributes.album.name_reading",
       help: "読み方"
-    
+
     field :slug, as: :text, required: true,
       translation_key: "activerecord.attributes.album.slug",
       help: "識別用スラッグ"
@@ -27,43 +27,43 @@ class Avo::Resources::Album < Avo::BaseResource
     field :release_circle_name, as: :text,
       translation_key: "activerecord.attributes.album.release_circle_name",
       help: "頒布主体サークル名（テキストで記録）"
-    
+
     field :release_date, as: :date,
       translation_key: "activerecord.attributes.album.release_date",
       help: "頒布日"
-    
+
     field :release_year, as: :number,
       translation_key: "activerecord.attributes.album.release_year",
       help: "頒布年"
-    
+
     field :release_month, as: :number,
       translation_key: "activerecord.attributes.album.release_month",
       help: "頒布月"
-    
+
     field :event_day, as: :belongs_to,
       translation_key: "activerecord.attributes.album.event_day",
       help: "頒布イベント日程"
-    
+
     field :album_number, as: :text,
       translation_key: "activerecord.attributes.album.album_number",
       help: "アルバムカタログ番号等"
-    
+
     field :credit, as: :trix,
       translation_key: "activerecord.attributes.album.credit",
       help: "クレジット情報"
-    
+
     field :introduction, as: :trix,
       translation_key: "activerecord.attributes.album.introduction",
       help: "短い紹介文"
-    
+
     field :description, as: :trix,
       translation_key: "activerecord.attributes.album.description",
       help: "詳細説明"
-    
+
     field :note, as: :textarea,
       translation_key: "activerecord.attributes.album.note",
       help: "メモ"
-    
+
     field :url, as: :text,
       translation_key: "activerecord.attributes.album.url",
       help: "アルバム公式URL"
@@ -73,7 +73,7 @@ class Avo::Resources::Album < Avo::BaseResource
 
     field :archived_at, as: :date_time,
       translation_key: "activerecord.attributes.album.archived_at"
-    
+
     field :position, as: :number,
       translation_key: "activerecord.attributes.album.position",
       help: "表示順序"

--- a/admin/app/avo/resources/album_disc.rb
+++ b/admin/app/avo/resources/album_disc.rb
@@ -1,26 +1,26 @@
 class Avo::Resources::AlbumDisc < Avo::BaseResource
   self.title = :name
   self.translation_key = "activerecord.resources.album_disc"
-  self.includes = [:album]
+  self.includes = [ :album ]
 
   def fields
     field :id, as: :id
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
-    
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
+
     # アルバムとの関連
     field :album, as: :belongs_to
 
     # 基本情報
-    field :disc_number, as: :number, 
+    field :disc_number, as: :number,
       help: "ディスクの通し番号（1枚目=1、2枚目=2など）"
-    
+
     field :name, as: :text,
       help: "ディスク名（必要な場合）"
-    
+
     field :description, as: :textarea,
       help: "ディスクに関する説明（例: ボーナスディスクの詳細など）"
-    
+
     field :note, as: :textarea,
       help: "備考"
 

--- a/admin/app/avo/resources/artist.rb
+++ b/admin/app/avo/resources/artist.rb
@@ -1,17 +1,17 @@
 class Avo::Resources::Artist < Avo::BaseResource
   self.title = :name
   self.translation_key = "activerecord.resources.artist"
-  self.includes = [:artist_names]
+  self.includes = [ :artist_names ]
 
   def fields
     field :id, as: :id, translation_key: "activerecord.attributes.artist.id"
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :name, as: :text, required: true,
       translation_key: "activerecord.attributes.artist.name",
       help: "開発・管理用の内部名"
-    
+
     field :note, as: :textarea,
       translation_key: "activerecord.attributes.artist.note",
       help: "補足情報"

--- a/admin/app/avo/resources/artist_name.rb
+++ b/admin/app/avo/resources/artist_name.rb
@@ -1,21 +1,21 @@
 class Avo::Resources::ArtistName < Avo::BaseResource
   self.title = :name
   self.translation_key = "activerecord.resources.artist_name"
-  self.includes = [:artist]
+  self.includes = [ :artist ]
 
   def fields
     field :id, as: :id
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :artist, as: :belongs_to, required: true
-    
+
     field :name, as: :text, required: true,
       help: "名義"
-    
+
     field :name_reading, as: :text,
       help: "名義読み方"
-    
+
     field :is_main_name, as: :boolean, required: true,
       help: "本名義フラグ"
 
@@ -29,16 +29,16 @@ class Avo::Resources::ArtistName < Avo::BaseResource
         "漢字": :kanji,
         "その他": :other
       }
-    
+
     field :first_character, as: :text,
       help: "頭文字詳細 (英字、ひらがな、カタカナの場合のみ)"
-    
+
     field :first_character_row, as: :text,
       help: "頭文字の行 (ひらがな、カタカナの場合のみ)"
-    
+
     field :description, as: :trix,
       help: "名義に関する説明文"
-    
+
     field :note, as: :textarea,
       help: "メモ"
 

--- a/admin/app/avo/resources/artist_role.rb
+++ b/admin/app/avo/resources/artist_role.rb
@@ -5,15 +5,15 @@ class Avo::Resources::ArtistRole < Avo::BaseResource
 
   def fields
     field :id, as: :id
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :name, as: :text, required: true,
       help: "役割名(vocalist, composer等)"
-    
+
     field :description, as: :trix,
       help: "役割の意味説明"
-    
+
     field :note, as: :textarea,
       help: "メモ"
 

--- a/admin/app/avo/resources/circle.rb
+++ b/admin/app/avo/resources/circle.rb
@@ -5,15 +5,15 @@ class Avo::Resources::Circle < Avo::BaseResource
 
   def fields
     field :id, as: :id
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :name, as: :text, required: true,
       help: "サークル名"
-    
+
     field :name_reading, as: :text,
       help: "読み方"
-    
+
     field :slug, as: :text, required: true,
       help: "識別用スラッグ"
 
@@ -27,16 +27,16 @@ class Avo::Resources::Circle < Avo::BaseResource
         "漢字": :kanji,
         "その他": :other
       }
-    
+
     field :first_character, as: :text,
       help: "頭文字詳細 (英字、ひらがな、カタカナの場合のみ)"
-    
+
     field :first_character_row, as: :text,
       help: "頭文字の行 (ひらがな、カタカナの場合のみ)"
-    
+
     field :description, as: :trix,
       help: "サークル説明"
-    
+
     field :note, as: :textarea,
       help: "メモ"
 

--- a/admin/app/avo/resources/distribution_service.rb
+++ b/admin/app/avo/resources/distribution_service.rb
@@ -5,25 +5,25 @@ class Avo::Resources::DistributionService < Avo::BaseResource
 
   def fields
     field :id, as: :id
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :service_name, as: :text, required: true,
       help: "サービス内部名（例: spotify）"
-    
+
     field :display_name, as: :text, required: true,
       help: "ユーザー向け表示名（例: Spotify）"
-    
+
     field :base_urls, as: :code,
       language: "json",
       help: "サービスの基本URLリスト（例: [\"https://open.spotify.com/\"]）"
-    
+
     field :description, as: :trix,
       help: "サービスの説明文"
-    
+
     field :note, as: :textarea,
       help: "メモや補足"
-    
+
     field :position, as: :number,
       help: "表示順序"
 

--- a/admin/app/avo/resources/event_day.rb
+++ b/admin/app/avo/resources/event_day.rb
@@ -1,43 +1,43 @@
 class Avo::Resources::EventDay < Avo::BaseResource
   self.title = :date
   self.translation_key = "activerecord.resources.event_day"
-  self.includes = [:event_edition]
+  self.includes = [ :event_edition ]
 
   def fields
     field :id, as: :id
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :event_edition, as: :belongs_to, required: true
-    
+
     field :day_number, as: :number,
       help: "イベント中の何日目か（1日目=1,2日目=2など）"
-    
+
     field :display_name, as: :text,
       help: "日程表示名（1日目、Day 1など）"
-    
+
     field :event_date, as: :date,
       help: "実際の開催日付"
-    
+
     field :region_code, as: :text, required: true,
       default: "JP",
       help: "開催地域コード"
-    
+
     field :is_cancelled, as: :boolean, required: true,
       help: "中止フラグ"
-    
+
     field :is_online, as: :boolean, required: true,
       help: "オンライン開催フラグ"
-    
+
     field :description, as: :trix,
       help: "日ごとの説明"
-    
+
     field :note, as: :textarea,
       help: "メモ"
 
     field :published_at, as: :date_time
     field :archived_at, as: :date_time
-    
+
     field :position, as: :number,
       help: "表示順序"
 

--- a/admin/app/avo/resources/event_edition.rb
+++ b/admin/app/avo/resources/event_edition.rb
@@ -1,45 +1,45 @@
 class Avo::Resources::EventEdition < Avo::BaseResource
   self.title = :name
   self.translation_key = "activerecord.resources.event_edition"
-  self.includes = [:event_series, :event_days]
+  self.includes = [ :event_series, :event_days ]
 
   def fields
     field :id, as: :id
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :event_series, as: :belongs_to, required: true
-    
+
     field :name, as: :text, required: true,
       help: "開催回内部名"
-    
+
     field :display_name, as: :text, required: true,
       help: "ユーザー表示名（例: コミックマーケット104）"
-    
+
     field :slug, as: :text, required: true,
       help: "識別用スラッグ"
-    
+
     field :start_date, as: :date,
       help: "開催開始日"
-    
+
     field :end_date, as: :date,
       help: "開催終了日"
-    
+
     field :description, as: :trix,
       help: "この開催回に関する説明"
-    
+
     field :note, as: :textarea,
       help: "メモ"
-    
+
     field :url, as: :text,
       help: "イベント公式URL"
-    
+
     field :twitter_url, as: :text,
       help: "イベント公式Twitter URL"
 
     field :published_at, as: :date_time
     field :archived_at, as: :date_time
-    
+
     field :position, as: :number,
       help: "表示順序"
 

--- a/admin/app/avo/resources/event_series.rb
+++ b/admin/app/avo/resources/event_series.rb
@@ -1,25 +1,25 @@
 class Avo::Resources::EventSeries < Avo::BaseResource
   self.title = :name
   self.translation_key = "activerecord.resources.event_series"
-  self.includes = [:event_editions]
+  self.includes = [ :event_editions ]
 
   def fields
     field :id, as: :id
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :name, as: :text, required: true,
       help: "システム管理名(内部名)"
-    
+
     field :display_name, as: :text, required: true,
       help: "ユーザー向け表示名"
-    
+
     field :slug, as: :text, required: true,
       help: "外部公開用の簡易識別子"
 
     field :published_at, as: :date_time
     field :archived_at, as: :date_time
-    
+
     field :position, as: :number,
       help: "表示順序"
 

--- a/admin/app/avo/resources/genre.rb
+++ b/admin/app/avo/resources/genre.rb
@@ -5,15 +5,15 @@ class Avo::Resources::Genre < Avo::BaseResource
 
   def fields
     field :id, as: :id
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :name, as: :text, required: true,
       help: "ジャンル名（ユニーク）"
-    
+
     field :description, as: :trix,
       help: "ジャンルの簡易説明"
-    
+
     field :note, as: :textarea,
       help: "ジャンルに関する補足情報"
 

--- a/admin/app/avo/resources/original_song.rb
+++ b/admin/app/avo/resources/original_song.rb
@@ -1,40 +1,40 @@
 class Avo::Resources::OriginalSong < Avo::BaseResource
   self.title = :title
   self.translation_key = "activerecord.resources.original_song"
-  self.includes = [:product, :origin_original_song]
+  self.includes = [ :product, :origin_original_song ]
 
   def fields
     field :id, as: :text
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :product, as: :belongs_to, required: true
-    
+
     field :name, as: :text, required: true,
       help: "原曲名"
-    
+
     field :name_reading, as: :text,
       help: "原曲名読み方"
-    
+
     field :composer, as: :text,
       help: "作曲者"
-    
+
     field :arranger, as: :text,
       help: "編曲者（原作側）"
-    
+
     field :track_number, as: :number, required: true,
       help: "作品中でのトラック番号"
-    
+
     field :is_original, as: :boolean, required: true,
       help: "初出オリジナル曲か否か"
-    
+
     field :origin_original_song, as: :belongs_to,
       help: "派生元となった原曲"
 
     # 逆方向の関連
     field :derived_original_songs, as: :has_many,
       help: "この原曲から派生した原曲"
-    
+
     field :songs, as: :has_many, through: :songs_original_songs
   end
 end

--- a/admin/app/avo/resources/product.rb
+++ b/admin/app/avo/resources/product.rb
@@ -1,22 +1,22 @@
 class Avo::Resources::Product < Avo::BaseResource
   self.title = :title
   self.translation_key = "activerecord.resources.product"
-  self.includes = [:original_songs]
+  self.includes = [ :original_songs ]
 
   def fields
     field :id, as: :text
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :name, as: :text, required: true,
       help: "原作作品名（例: 東方紅魔郷）"
-    
+
     field :name_reading, as: :text,
       help: "作品名の読み仮名"
-    
+
     field :short_name, as: :text, required: true,
       help: "短縮名（略称）"
-    
+
     field :product_type, as: :select, required: true,
       options: {
         "PC-98作品": :pc98,
@@ -28,7 +28,7 @@ class Avo::Resources::Product < Avo::BaseResource
         "その他": :other
       },
       help: "作品タイプ"
-    
+
     field :series_number, as: :number, required: true,
       help: "シリーズ中での作品番号（例: 6.00 = 東方紅魔郷）"
 

--- a/admin/app/avo/resources/shop.rb
+++ b/admin/app/avo/resources/shop.rb
@@ -5,31 +5,31 @@ class Avo::Resources::Shop < Avo::BaseResource
 
   def fields
     field :id, as: :id
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :name, as: :text, required: true,
       help: "内部システムで用いるショップの識別名(ユニーク)"
-    
+
     field :display_name, as: :text, required: true,
       help: "表示用のショップ名"
-    
+
     field :description, as: :trix,
       help: "ショップの説明"
-    
+
     field :note, as: :textarea,
       help: "備考"
-    
+
     field :website_url, as: :text,
       help: "公式サイトURL"
-    
+
     field :base_urls, as: :code,
       language: "json",
       help: "このショップに関連するベースURLリスト(json形式)"
 
     field :published_at, as: :date_time
     field :archived_at, as: :date_time
-    
+
     field :position, as: :number,
       help: "表示順序"
 

--- a/admin/app/avo/resources/song.rb
+++ b/admin/app/avo/resources/song.rb
@@ -1,32 +1,32 @@
 class Avo::Resources::Song < Avo::BaseResource
   self.title = :title
   self.translation_key = "activerecord.resources.song"
-  self.includes = [:circle, :album, :album_disc, :original_songs]
+  self.includes = [ :circle, :album, :album_disc, :original_songs ]
 
   def fields
     field :id, as: :id, translation_key: "activerecord.attributes.song.id"
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :circle, as: :belongs_to
     field :album, as: :belongs_to
-    
+
     field :name, as: :text, required: true,
       translation_key: "activerecord.attributes.song.name",
       help: "楽曲名（正式タイトル）"
-    
+
     field :name_reading, as: :text,
       help: "名前読み方"
-    
+
     field :release_date, as: :date,
       help: "頒布日"
-    
+
     field :release_year, as: :number,
       help: "頒布年"
-    
+
     field :release_month, as: :number,
       help: "頒布月"
-    
+
     field :slug, as: :text, required: true,
       help: "識別用スラッグ"
 
@@ -35,18 +35,18 @@ class Avo::Resources::Song < Avo::BaseResource
     field :track_number, as: :number,
       translation_key: "activerecord.attributes.song.track_number",
       help: "トラック番号"
-    
+
     field :length_time_ms, as: :number,
       translation_key: "activerecord.attributes.song.length",
       help: "曲の長さ(ミリ秒)"
-    
+
     field :bpm, as: :number,
       translation_key: "activerecord.attributes.song.bpm",
       help: "BPM"
-    
+
     field :description, as: :trix,
       help: "楽曲に関する説明文"
-    
+
     field :note, as: :textarea,
       help: "メモ"
 
@@ -60,7 +60,7 @@ class Avo::Resources::Song < Avo::BaseResource
 
     field :published_at, as: :date_time
     field :archived_at, as: :date_time
-    
+
     field :position, as: :number,
       help: "表示順序"
 

--- a/admin/app/avo/resources/tag.rb
+++ b/admin/app/avo/resources/tag.rb
@@ -5,15 +5,15 @@ class Avo::Resources::Tag < Avo::BaseResource
 
   def fields
     field :id, as: :id
-    field :created_at, as: :date_time, hide_on: [:index]
-    field :updated_at, as: :date_time, hide_on: [:index]
+    field :created_at, as: :date_time, hide_on: [ :index ]
+    field :updated_at, as: :date_time, hide_on: [ :index ]
 
     field :name, as: :text, required: true,
       help: "タグ名（ユニーク）"
-    
+
     field :description, as: :trix,
       help: "タグに関する説明文"
-    
+
     field :note, as: :textarea,
       help: "タグに関する補足情報"
 

--- a/admin/config/initializers/avo.rb
+++ b/admin/config/initializers/avo.rb
@@ -158,8 +158,8 @@ Avo.configure do |config|
   #   link "Profile", path: "/avo/profile", icon: "heroicons/outline/user-circle"
   # }
 
-  config.home_path = '/admin/resources/albums'
-  
+  config.home_path = "/admin/resources/albums"
+
   # リソースを明示的に登録
   config.resources = [
     "Avo::Resources::Album",
@@ -182,7 +182,7 @@ Avo.configure do |config|
 
   # 1ページあたりの表示件数
   config.per_page = 25
-  
+
   # ID列をクリックしてリソースの詳細を表示
   config.id_links_to_resource = true
 


### PR DESCRIPTION
- Added RuboCop commands to the Makefile for code quality checks.
- Updated Gemfile to use double quotes for consistency.
- Refactored resource files to improve formatting and readability, including spacing adjustments in includes and field definitions across various resources (Album, Artist, Circle, etc.).
- Ensured consistent hiding of created_at and updated_at fields in resource definitions.
- Improved documentation comments for clarity in resource fields.