### PR TITLE
feat: テーマ切り替え機能の強化

### DIFF
--- a/frontend/app/components/layouts/header.tsx
+++ b/frontend/app/components/layouts/header.tsx
@@ -12,11 +12,11 @@ import {
   AvatarFallback,
   AvatarImage,
 } from "../../components/ui/avatar"
-import { Badge } from "../../components/ui/badge"
 import { cn } from "../../lib/utils"
-import { MenuIcon, LogIn, LogOut, User, ChevronDown, Settings, GitBranch, Bell } from "lucide-react"
+import { MenuIcon, LogIn, LogOut, User, ChevronDown, Settings, Bell } from "lucide-react"
 import type { loader } from "../../root"
 import type { User as UserType } from "../../types/auth"
+import { ThemeSwitch } from "../../components/theme-switch"
 
 interface Route {
   href: string
@@ -60,6 +60,7 @@ export function Header() {
           </div>
           <div className="flex items-center gap-3">
             <NotificationBadge />
+            <ThemeSwitch />
             {isAuthenticated ? (
               <UserNav user={user} />
             ) : (
@@ -111,6 +112,10 @@ function MobileNav({ isAuthenticated }: { isAuthenticated: boolean }) {
               </Link>
             ))}
             <div className="mt-4 border-t pt-4 dark:border-neutral-800">
+              <div className="flex items-center justify-between mb-4">
+                <span className="text-neutral-600 dark:text-neutral-400">テーマ</span>
+                <ThemeSwitch />
+              </div>
               {isAuthenticated ? (
                 <Link
                   to="/logout"

--- a/frontend/app/components/theme-provider.tsx
+++ b/frontend/app/components/theme-provider.tsx
@@ -1,0 +1,6 @@
+import type { ThemeProviderProps } from 'next-themes'
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/frontend/app/components/theme-switch.tsx
+++ b/frontend/app/components/theme-switch.tsx
@@ -1,0 +1,58 @@
+import { Check, Moon, Sun } from 'lucide-react'
+import { useTheme } from 'next-themes'
+import { useEffect } from 'react'
+import { Button } from '~/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '~/components/ui/dropdown-menu'
+import { cn } from '~/lib/utils'
+
+export function ThemeSwitch() {
+  const { theme, setTheme } = useTheme()
+
+  /* Update theme-color meta tag
+   * when theme is updated */
+  useEffect(() => {
+    const themeColor = theme === 'dark' ? '#020817' : '#fff'
+    const metaThemeColor = document.querySelector("meta[name='theme-color']")
+    if (metaThemeColor) metaThemeColor.setAttribute('content', themeColor)
+  }, [theme])
+
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="scale-95 rounded-full">
+          <Sun className="size-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+          <Moon className="absolute size-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme('light')}>
+          Light{' '}
+          <Check
+            size={14}
+            className={cn('ml-auto', theme !== 'light' && 'hidden')}
+          />
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('dark')}>
+          Dark
+          <Check
+            size={14}
+            className={cn('ml-auto', theme !== 'dark' && 'hidden')}
+          />
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('system')}>
+          System
+          <Check
+            size={14}
+            className={cn('ml-auto', theme !== 'system' && 'hidden')}
+          />
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -12,7 +12,7 @@ import type { LoaderFunctionArgs } from "react-router";
 import { authenticator, isAuthenticated } from "~/services/auth.server";
 import { Header } from "./components/layouts/header";
 import { Footer } from "./components/layouts/footer";
-
+import { ThemeProvider } from "./components/theme-provider";
 export async function loader({ request }: LoaderFunctionArgs) {
   // ユーザーの認証状態を確認
   try {
@@ -56,7 +56,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
   const isLoginPage = location.pathname === "/login";
 
   return (
-    <html lang="ja">
+    <html lang="ja" suppressHydrationWarning>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -64,11 +64,11 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body className="min-h-screen flex flex-col">
-        <Header />
-        <div className="flex-1">
-          {children}
-        </div>
-        <Footer />
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <Header />
+          <div className="flex-1">{children}</div>
+          <Footer />
+        </ThemeProvider>
         <ScrollRestoration />
         <Scripts />
       </body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "drizzle-orm": "^0.43.1",
         "isbot": "^5.1.27",
         "lucide-react": "^0.503.0",
+        "next-themes": "^0.4.6",
         "pg": "^8.15.5",
         "pg-connection-string": "^2.6.2",
         "react": "^19.0.0",
@@ -6007,6 +6008,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/node-releases": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "drizzle-orm": "^0.43.1",
     "isbot": "^5.1.27",
     "lucide-react": "^0.503.0",
+    "next-themes": "^0.4.6",
     "pg": "^8.15.5",
     "pg-connection-string": "^2.6.2",
     "react": "^19.0.0",


### PR DESCRIPTION
- `next-themes`パッケージを追加し、テーマ切り替え機能を実装しました。
- 新しい`ThemeProvider`コンポーネントを作成し、アプリ全体でテーマの管理を行います。
- ヘッダーとモバイルナビゲーションにテーマ切り替えオプションを追加しました。
- テーマの状態を管理するためのカスタムフックを使用し、ユーザーの選択に応じてテーマを変更できるようにしました。