### PR TITLE
feat: ユーザー管理機能の追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ down:
 migrate:
 	docker compose run --rm dbmate up
 	docker compose run --rm dbmate -e TEST_DATABASE_URL --no-dump-schema up
+	docker compose run --rm admin bin/rails db:migrate
+	make drizzle-pull
 
 drop:
 	docker compose run --rm dbmate drop

--- a/admin/db/schema.rb
+++ b/admin/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_18_055109) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_01_143011) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -547,6 +547,45 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_18_055109) do
     t.unique_constraint ["name"], name: "tags_name_key"
   end
 
+  create_table "user_authentications", id: { type: :uuid, default: -> { "gen_random_uuid()" }, comment: "認証情報ID" }, comment: "ユーザーの外部認証（Auth0など）情報を管理するテーブル", force: :cascade do |t|
+    t.timestamptz "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false, comment: "作成日時"
+    t.timestamptz "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false, comment: "更新日時"
+    t.uuid "user_id", null: false, comment: "関連するアプリケーションユーザーID"
+    t.text "auth0_user_id", null: false, comment: "Auth0から払い出されるユーザーID"
+    t.timestamptz "last_login_at", comment: "アプリケーションでの最終ログイン日時（Auth0のデータと同期するか検討）"
+    t.index ["auth0_user_id"], name: "idx_user_authentications_auth0_user_id"
+    t.index ["user_id"], name: "idx_user_authentications_user_id"
+    t.unique_constraint ["auth0_user_id"], name: "user_authentications_auth0_user_id_key"
+    t.unique_constraint ["user_id"], name: "user_authentications_user_id_key"
+  end
+
+  create_table "user_profiles", id: { type: :uuid, default: -> { "gen_random_uuid()" }, comment: "プロフィール情報ID" }, comment: "ユーザーのプロフィール情報を管理するテーブル", force: :cascade do |t|
+    t.timestamptz "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false, comment: "作成日時"
+    t.timestamptz "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false, comment: "更新日時"
+    t.uuid "user_id", null: false, comment: "関連するユーザーID"
+    t.text "username", null: false
+    t.text "display_name", null: false, comment: "表示名"
+    t.text "bio", comment: "自己紹介"
+    t.text "avatar_url", comment: "アバター画像のURL"
+    t.index ["user_id"], name: "idx_user_profiles_user_id"
+    t.unique_constraint ["user_id"], name: "user_profiles_user_id_key"
+    t.unique_constraint ["username"], name: "user_profiles_username_key"
+  end
+
+  create_table "user_settings", id: { type: :uuid, default: -> { "gen_random_uuid()" }, comment: "設定情報ID" }, comment: "ユーザーのアプリケーション設定を管理するテーブル", force: :cascade do |t|
+    t.timestamptz "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false, comment: "作成日時"
+    t.timestamptz "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false, comment: "更新日時"
+    t.uuid "user_id", null: false, comment: "関連するユーザーID"
+    t.boolean "is_public_profile", default: false, null: false, comment: "プロフィールを公開するかどうか"
+    t.index ["user_id"], name: "idx_user_settings_user_id"
+    t.unique_constraint ["user_id"], name: "user_settings_user_id_key"
+  end
+
+  create_table "users", id: { type: :uuid, default: -> { "gen_random_uuid()" }, comment: "ユーザーID" }, comment: "サイトのユーザー基本情報を管理するテーブル（最小限の情報のみ）", force: :cascade do |t|
+    t.timestamptz "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false, comment: "作成日時"
+    t.timestamptz "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false, comment: "更新日時"
+  end
+
   add_foreign_key "album_discs", "albums", name: "album_discs_album_id_fkey", on_delete: :cascade
   add_foreign_key "album_prices", "albums", name: "album_prices_album_id_fkey", on_delete: :cascade
   add_foreign_key "album_prices", "shops", name: "album_prices_shop_id_fkey", on_delete: :restrict
@@ -578,4 +617,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_18_055109) do
   add_foreign_key "songs_original_songs", "songs", name: "songs_original_songs_song_id_fkey", on_delete: :cascade
   add_foreign_key "streamable_urls", "distribution_services", column: "service_name", primary_key: "service_name", name: "streamable_urls_service_name_fkey", on_delete: :restrict
   add_foreign_key "taggings", "tags", name: "taggings_tag_id_fkey", on_delete: :cascade
+  add_foreign_key "user_authentications", "users", name: "user_authentications_user_id_fkey", on_delete: :cascade
+  add_foreign_key "user_profiles", "users", name: "user_profiles_user_id_fkey", on_delete: :cascade
+  add_foreign_key "user_settings", "users", name: "user_settings_user_id_fkey", on_delete: :cascade
 end

--- a/db/migrations/20250501143011_create_users_table.sql
+++ b/db/migrations/20250501143011_create_users_table.sql
@@ -1,0 +1,71 @@
+-- migrate:up
+create table users (
+    id            uuid                     not null primary key default gen_random_uuid(),
+    created_at    timestamp with time zone not null default current_timestamp,
+    updated_at    timestamp with time zone not null default current_timestamp
+);
+comment on table users is 'サイトのユーザー基本情報を管理するテーブル（最小限の情報のみ）';
+comment on column users.id is 'ユーザーID';
+comment on column users.created_at is '作成日時';
+comment on column users.updated_at is '更新日時';
+
+create table user_authentications (
+    id                 uuid                     not null primary key default gen_random_uuid(),
+    created_at         timestamp with time zone not null default current_timestamp,
+    updated_at         timestamp with time zone not null default current_timestamp,
+    user_id            uuid                     not null unique references users(id) on delete cascade, -- アプリケーションのユーザーID
+    auth0_user_id      text                     not null unique, -- Auth0から払い出されるユニークなユーザーID (例: auth0|abcdef123456)
+    last_login_at      timestamp with time zone
+);
+create index idx_user_authentications_user_id on user_authentications (user_id);
+create index idx_user_authentications_auth0_user_id on user_authentications (auth0_user_id);
+comment on table user_authentications is 'ユーザーの外部認証（Auth0など）情報を管理するテーブル';
+comment on column user_authentications.id is '認証情報ID';
+comment on column user_authentications.created_at is '作成日時';
+comment on column user_authentications.updated_at is '更新日時';
+comment on column user_authentications.user_id is '関連するアプリケーションユーザーID';
+comment on column user_authentications.auth0_user_id is 'Auth0から払い出されるユーザーID';
+comment on column user_authentications.last_login_at is 'アプリケーションでの最終ログイン日時（Auth0のデータと同期するか検討）';
+
+create table user_profiles (
+    id            uuid                     not null primary key default gen_random_uuid(),
+    created_at    timestamp with time zone not null default current_timestamp,
+    updated_at    timestamp with time zone not null default current_timestamp,
+    user_id       uuid                     not null unique references users(id) on delete cascade,
+    username      text                     not null unique,
+    display_name  text                     not null,
+    bio           text,
+    avatar_url    text
+);
+create index idx_user_profiles_user_id on user_profiles (user_id); -- 外部キーには通常インデックスが推奨される
+comment on table user_profiles is 'ユーザーのプロフィール情報を管理するテーブル';
+comment on column user_profiles.id is 'プロフィール情報ID';
+comment on column user_profiles.created_at is '作成日時';
+comment on column user_profiles.updated_at is '更新日時';
+comment on column user_profiles.user_id is '関連するユーザーID';
+comment on column user_profiles.display_name is '表示名';
+comment on column user_profiles.bio is '自己紹介';
+comment on column user_profiles.avatar_url is 'アバター画像のURL';
+
+create table user_settings (
+    id                       uuid                     not null primary key default gen_random_uuid(),
+    created_at               timestamp with time zone not null default current_timestamp,
+    updated_at               timestamp with time zone not null default current_timestamp,
+    user_id                  uuid                     not null unique references users(id) on delete cascade,
+    is_public_profile        boolean                  not null default false
+);
+create index idx_user_settings_user_id on user_settings (user_id);
+comment on table user_settings is 'ユーザーのアプリケーション設定を管理するテーブル';
+comment on column user_settings.id is '設定情報ID';
+comment on column user_settings.created_at is '作成日時';
+comment on column user_settings.updated_at is '更新日時';
+comment on column user_settings.user_id is '関連するユーザーID';
+comment on column user_settings.is_public_profile is 'プロフィールを公開するかどうか';
+
+-- migrate:down
+
+-- テーブルの削除は依存関係のある順序で実行
+drop table if exists user_settings cascade;
+drop table if exists user_profiles cascade;
+drop table if exists user_authentications cascade;
+drop table if exists users cascade;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -563,6 +563,18 @@ COMMENT ON COLUMN public.albums_circles."position" IS '複数サークルが関�
 
 
 --
+-- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ar_internal_metadata (
+    key character varying NOT NULL,
+    value character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: artist_names; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3007,6 +3019,235 @@ COMMENT ON COLUMN public.tags.note IS 'タグに関する補足情報';
 
 
 --
+-- Name: user_authentications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_authentications (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    user_id uuid NOT NULL,
+    auth0_user_id text NOT NULL,
+    last_login_at timestamp with time zone
+);
+
+
+--
+-- Name: TABLE user_authentications; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.user_authentications IS 'ユーザーの外部認証（Auth0など）情報を管理するテーブル';
+
+
+--
+-- Name: COLUMN user_authentications.id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_authentications.id IS '認証情報ID';
+
+
+--
+-- Name: COLUMN user_authentications.created_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_authentications.created_at IS '作成日時';
+
+
+--
+-- Name: COLUMN user_authentications.updated_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_authentications.updated_at IS '更新日時';
+
+
+--
+-- Name: COLUMN user_authentications.user_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_authentications.user_id IS '関連するアプリケーションユーザーID';
+
+
+--
+-- Name: COLUMN user_authentications.auth0_user_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_authentications.auth0_user_id IS 'Auth0から払い出されるユーザーID';
+
+
+--
+-- Name: COLUMN user_authentications.last_login_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_authentications.last_login_at IS 'アプリケーションでの最終ログイン日時（Auth0のデータと同期するか検討）';
+
+
+--
+-- Name: user_profiles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_profiles (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    user_id uuid NOT NULL,
+    username text NOT NULL,
+    display_name text NOT NULL,
+    bio text,
+    avatar_url text
+);
+
+
+--
+-- Name: TABLE user_profiles; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.user_profiles IS 'ユーザーのプロフィール情報を管理するテーブル';
+
+
+--
+-- Name: COLUMN user_profiles.id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_profiles.id IS 'プロフィール情報ID';
+
+
+--
+-- Name: COLUMN user_profiles.created_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_profiles.created_at IS '作成日時';
+
+
+--
+-- Name: COLUMN user_profiles.updated_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_profiles.updated_at IS '更新日時';
+
+
+--
+-- Name: COLUMN user_profiles.user_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_profiles.user_id IS '関連するユーザーID';
+
+
+--
+-- Name: COLUMN user_profiles.display_name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_profiles.display_name IS '表示名';
+
+
+--
+-- Name: COLUMN user_profiles.bio; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_profiles.bio IS '自己紹介';
+
+
+--
+-- Name: COLUMN user_profiles.avatar_url; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_profiles.avatar_url IS 'アバター画像のURL';
+
+
+--
+-- Name: user_settings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_settings (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    user_id uuid NOT NULL,
+    is_public_profile boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: TABLE user_settings; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.user_settings IS 'ユーザーのアプリケーション設定を管理するテーブル';
+
+
+--
+-- Name: COLUMN user_settings.id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_settings.id IS '設定情報ID';
+
+
+--
+-- Name: COLUMN user_settings.created_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_settings.created_at IS '作成日時';
+
+
+--
+-- Name: COLUMN user_settings.updated_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_settings.updated_at IS '更新日時';
+
+
+--
+-- Name: COLUMN user_settings.user_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_settings.user_id IS '関連するユーザーID';
+
+
+--
+-- Name: COLUMN user_settings.is_public_profile; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.user_settings.is_public_profile IS 'プロフィールを公開するかどうか';
+
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.users (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: TABLE users; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.users IS 'サイトのユーザー基本情報を管理するテーブル（最小限の情報のみ）';
+
+
+--
+-- Name: COLUMN users.id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.users.id IS 'ユーザーID';
+
+
+--
+-- Name: COLUMN users.created_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.users.created_at IS '作成日時';
+
+
+--
+-- Name: COLUMN users.updated_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.users.updated_at IS '更新日時';
+
+
+--
 -- Name: album_discs album_discs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3052,6 +3293,14 @@ ALTER TABLE ONLY public.albums
 
 ALTER TABLE ONLY public.albums
     ADD CONSTRAINT albums_slug_key UNIQUE (slug);
+
+
+--
+-- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ar_internal_metadata
+    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
 --
@@ -3356,6 +3605,78 @@ ALTER TABLE ONLY public.tags
 
 ALTER TABLE ONLY public.tags
     ADD CONSTRAINT tags_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_authentications user_authentications_auth0_user_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_authentications
+    ADD CONSTRAINT user_authentications_auth0_user_id_key UNIQUE (auth0_user_id);
+
+
+--
+-- Name: user_authentications user_authentications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_authentications
+    ADD CONSTRAINT user_authentications_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_authentications user_authentications_user_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_authentications
+    ADD CONSTRAINT user_authentications_user_id_key UNIQUE (user_id);
+
+
+--
+-- Name: user_profiles user_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_profiles
+    ADD CONSTRAINT user_profiles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_profiles user_profiles_user_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_profiles
+    ADD CONSTRAINT user_profiles_user_id_key UNIQUE (user_id);
+
+
+--
+-- Name: user_profiles user_profiles_username_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_profiles
+    ADD CONSTRAINT user_profiles_username_key UNIQUE (username);
+
+
+--
+-- Name: user_settings user_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_settings
+    ADD CONSTRAINT user_settings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_settings user_settings_user_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_settings
+    ADD CONSTRAINT user_settings_user_id_key UNIQUE (user_id);
+
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
 --
@@ -4129,6 +4450,34 @@ CREATE INDEX idx_taggings_position ON public.taggings USING btree ("position");
 
 
 --
+-- Name: idx_user_authentications_auth0_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_user_authentications_auth0_user_id ON public.user_authentications USING btree (auth0_user_id);
+
+
+--
+-- Name: idx_user_authentications_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_user_authentications_user_id ON public.user_authentications USING btree (user_id);
+
+
+--
+-- Name: idx_user_profiles_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_user_profiles_user_id ON public.user_profiles USING btree (user_id);
+
+
+--
+-- Name: idx_user_settings_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_user_settings_user_id ON public.user_settings USING btree (user_id);
+
+
+--
 -- Name: uk_album_upcs_album_id_upc; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4489,6 +4838,30 @@ ALTER TABLE ONLY public.taggings
 
 
 --
+-- Name: user_authentications user_authentications_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_authentications
+    ADD CONSTRAINT user_authentications_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: user_profiles user_profiles_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_profiles
+    ADD CONSTRAINT user_profiles_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: user_settings user_settings_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_settings
+    ADD CONSTRAINT user_settings_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -4498,4 +4871,5 @@ ALTER TABLE ONLY public.taggings
 --
 
 INSERT INTO public.schema_migrations (version) VALUES
-    ('20250118055109');
+    ('20250118055109'),
+    ('20250501143011');

--- a/frontend/drizzle/relations.ts
+++ b/frontend/drizzle/relations.ts
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm/relations";
-import { products, original_songs, distribution_services, streamable_urls, event_series, event_editions, event_days, artists, artist_names, circles, albums, albums_circles, album_prices, shops, album_upcs, album_discs, songs, song_lyrics, song_bmps, song_isrcs, songs_arrange_circles, songs_original_songs, songs_artist_roles, artist_roles, songs_genres, genres, genreable_genres, tags, taggings } from "./schema";
+import { products, original_songs, distribution_services, streamable_urls, event_series, event_editions, event_days, artists, artist_names, circles, albums, albums_circles, album_prices, shops, album_upcs, album_discs, songs, song_lyrics, song_bmps, song_isrcs, songs_arrange_circles, songs_original_songs, songs_artist_roles, artist_roles, songs_genres, genres, genreable_genres, tags, taggings, users, user_authentications, user_profiles, user_settings } from "./schema";
 
 export const original_songsRelations = relations(original_songs, ({one, many}) => ({
 	product: one(products, {
@@ -244,4 +244,31 @@ export const taggingsRelations = relations(taggings, ({one}) => ({
 
 export const tagsRelations = relations(tags, ({many}) => ({
 	taggings: many(taggings),
+}));
+
+export const user_authenticationsRelations = relations(user_authentications, ({one}) => ({
+	user: one(users, {
+		fields: [user_authentications.user_id],
+		references: [users.id]
+	}),
+}));
+
+export const usersRelations = relations(users, ({many}) => ({
+	user_authentications: many(user_authentications),
+	user_profiles: many(user_profiles),
+	user_settings: many(user_settings),
+}));
+
+export const user_profilesRelations = relations(user_profiles, ({one}) => ({
+	user: one(users, {
+		fields: [user_profiles.user_id],
+		references: [users.id]
+	}),
+}));
+
+export const user_settingsRelations = relations(user_settings, ({one}) => ({
+	user: one(users, {
+		fields: [user_settings.user_id],
+		references: [users.id]
+	}),
 }));

--- a/frontend/drizzle/schema.ts
+++ b/frontend/drizzle/schema.ts
@@ -761,3 +761,64 @@ export const ar_internal_metadata = pgTable("ar_internal_metadata", {
 	created_at: timestamp({ precision: 6, mode: 'string' }).notNull(),
 	updated_at: timestamp({ precision: 6, mode: 'string' }).notNull(),
 });
+
+export const users = pgTable("users", {
+	id: uuid().defaultRandom().primaryKey().notNull(),
+	created_at: timestamp({ withTimezone: true, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`).notNull(),
+	updated_at: timestamp({ withTimezone: true, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`).notNull(),
+});
+
+export const user_authentications = pgTable("user_authentications", {
+	id: uuid().defaultRandom().primaryKey().notNull(),
+	created_at: timestamp({ withTimezone: true, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`).notNull(),
+	updated_at: timestamp({ withTimezone: true, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`).notNull(),
+	user_id: uuid().notNull(),
+	auth0_user_id: text().notNull(),
+	last_login_at: timestamp({ withTimezone: true, mode: 'string' }),
+}, (table) => [
+	index("idx_user_authentications_auth0_user_id").using("btree", table.auth0_user_id.asc().nullsLast().op("text_ops")),
+	index("idx_user_authentications_user_id").using("btree", table.user_id.asc().nullsLast().op("uuid_ops")),
+	foreignKey({
+			columns: [table.user_id],
+			foreignColumns: [users.id],
+			name: "user_authentications_user_id_fkey"
+		}).onDelete("cascade"),
+	unique("user_authentications_user_id_key").on(table.user_id),
+	unique("user_authentications_auth0_user_id_key").on(table.auth0_user_id),
+]);
+
+export const user_profiles = pgTable("user_profiles", {
+	id: uuid().defaultRandom().primaryKey().notNull(),
+	created_at: timestamp({ withTimezone: true, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`).notNull(),
+	updated_at: timestamp({ withTimezone: true, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`).notNull(),
+	user_id: uuid().notNull(),
+	username: text().notNull(),
+	display_name: text().notNull(),
+	bio: text(),
+	avatar_url: text(),
+}, (table) => [
+	index("idx_user_profiles_user_id").using("btree", table.user_id.asc().nullsLast().op("uuid_ops")),
+	foreignKey({
+			columns: [table.user_id],
+			foreignColumns: [users.id],
+			name: "user_profiles_user_id_fkey"
+		}).onDelete("cascade"),
+	unique("user_profiles_user_id_key").on(table.user_id),
+	unique("user_profiles_username_key").on(table.username),
+]);
+
+export const user_settings = pgTable("user_settings", {
+	id: uuid().defaultRandom().primaryKey().notNull(),
+	created_at: timestamp({ withTimezone: true, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`).notNull(),
+	updated_at: timestamp({ withTimezone: true, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`).notNull(),
+	user_id: uuid().notNull(),
+	is_public_profile: boolean().default(false).notNull(),
+}, (table) => [
+	index("idx_user_settings_user_id").using("btree", table.user_id.asc().nullsLast().op("uuid_ops")),
+	foreignKey({
+			columns: [table.user_id],
+			foreignColumns: [users.id],
+			name: "user_settings_user_id_fkey"
+		}).onDelete("cascade"),
+	unique("user_settings_user_id_key").on(table.user_id),
+]);


### PR DESCRIPTION
- ユーザー、ユーザー認証、ユーザープロフィール、ユーザー設定に関する新しいテーブルをデータベースに追加しました。
- `Makefile`にマイグレーションコマンドを追加し、データベースの初期化を簡素化しました。
- フロントエンドでのユーザー関連のリレーションを定義しました。
- スキーマファイルを更新し、新しいテーブルの構造とコメントを追加しました。