### PR TITLE
fix(ci): dependabotとrenovateのPRをClaude Code Reviewから除外

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,8 @@ on:
 jobs:
   claude-review:
     # Skip dependency bot PRs
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+    if: |
+      !contains(fromJSON('["dependabot[bot]", "renovate[bot]"]'), github.actor)
     
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Skip dependabot PRs
-    if: github.actor != 'dependabot[bot]'
+    # Skip dependency bot PRs
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip dependabot PRs
+    if: github.actor != 'dependabot[bot]'
     
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## 概要
dependabotとrenovateのPRに対してClaude Code Reviewワークフローが実行されないよう修正しました。

## 変更内容
- `github.actor \!= 'dependabot[bot]' && github.actor \!= 'renovate[bot]'`条件を追加
- 依存関係管理ボットのPRを自動的にスキップ

## 解決する問題
- dependabotのPRで発生していた権限エラー（401 Unauthorized）
- 不要なAPI呼び出しによるコスト増加
- 自動化されたPRに対する冗長なレビュー

## テスト計画
- [x] 通常のPRではClaude Code Reviewが実行される
- [x] dependabotのPRではワークフローがスキップされる
- [x] renovateのPRではワークフローがスキップされる